### PR TITLE
Fix closing code block delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ MicroAgentStack/
 ├── Other generator scripts...   # (e.g., inject\_fastapi\_metadata.py)
 └── README.md                    # (this file)
 
-````
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- fix closing code block delimiter in README so it matches the opening marker

## Testing
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_684a624dfaa483219eeeed51e40c5908